### PR TITLE
Remove default AMAZON_S3_BUCKET value

### DIFF
--- a/utils/getImageFromBucket.js
+++ b/utils/getImageFromBucket.js
@@ -1,6 +1,6 @@
 const axios = require('axios').default;
 
-const AMAZON_S3_BUCKET = process.env.AMAZON_S3_BUCKET || 'https://s3.amazonaws.com/mc-canvas/test';
+const AMAZON_S3_BUCKET = process.env.AMAZON_S3_BUCKET;
 const getImageFromBucket = async (name) => {
 
   if (!AMAZON_S3_BUCKET) throw new Error('No AMAZON_S3_BUCKET url provided');


### PR DESCRIPTION
Unless you'll open your test bucket for every user of this open-source library, I wouldn't recommend having a default one in the code. 
Also, don't explicitly expose your S3 bucket URL, attackers could take advantage of it.